### PR TITLE
Fix typo in Link to the "expectations" document

### DIFF
--- a/guidelines-for-pull-requests.md
+++ b/guidelines-for-pull-requests.md
@@ -20,7 +20,7 @@
 
   - **Be friendly!** Everyone is working hard and trying to be effective.
 
-  - **Have healthy expectations.** The workflow around Elm is optimized for throughput, not latency. This has tricky implications, so read more about it [here](expectations.md).
+  - **Have healthy expectations.** The workflow around Elm is optimized for throughput, not latency. This has tricky implications, so read more about it [here](https://github.com/elm/expectations).
 
 
 ## Hall of Fame


### PR DESCRIPTION
Just wanted to point out that the link is broken. I'm not sure what's the best practice for referencing documentation on github, I opted for an absolute link. Keep up the good work!